### PR TITLE
Zenity Dependency Check:  Compatibility Fix

### DIFF
--- a/gksudo2
+++ b/gksudo2
@@ -67,7 +67,7 @@ force_password () {  # prompt for password only if sudo does not. su is used to 
 }
 
 [[ ! -d /tmp/gk ]] && (mkdir -m0777 /tmp/gk)  # avoid sticky bit issues if su before running
-if [[ ! -e /bin/zenity ]]; then
+if [[ ! -e /bin/zenity && /usr/bin/zenity ]]; then
 	echo "STOP! Zenity is not found, and required to run gksudo2"
 	exit 1
 fi


### PR DESCRIPTION
Some package manager will place the the binary 'zenity' file under '/usr/bin' instead of '/bin' (alpine linux(apk) in my case)

patched the condition of the dependency check statement to make it trigger the warning and assert the program only when both '/bin/zenity' and '/usr/bin/zenity' don't exist

============================================================
And i noticed that there doesnt seem to be a issue section under this project so maybe im just gonna post it below:

so ive been looking for some solution for running GUI applications under wayland,(in my case i use sway and it just couldnt launch any gui apps with privileges) and for the past few days ive done tons of searching, i tried xhost, which wasnt really counts a decent workaround cuz doesnt apply the changes nor globally and permanent, and comes with some security issues which in my case doesnt matter that much.

and i tried polkit-->pkexec as some of my friends recommended, after installing some other authentication agent due to some ancient bugs left with pkttyagent, it still doesnt seem to be working and i saw it mentioned under archwiki that states pkexec wont help in wayland

so i found this project, fixed the issue above and ran it and still i ran into some errors i guess.
first i run `gksudo2` to test if it installed correctly, it pops up a box that notice me i need to pass some arguments which means it should be installed correctly
and then i tried `gksudo2 gparted` and it pops up a notification box again comes with an error: 
`gksudo2 incolked allowing "root" access to this display server!`
and then it asked me to authenticate with password, and i passed the password and clicked OK
and then another error box pops up:
`Error! if cryptic, possibly from unclean exit of child process
/tmp/gk/gk-env-cmd:line13:dbus-launch:command not found`

and i pressed ok, and then not thing happens, might be some bug of something?

really looking forward to see this tool being usable, my workflow requires me to use some distrobox podman containers under alpine linux so those partially fixes werent for me and xhost works but its wasnt quite a decent workaround :D

*and here comes the log although i guess there wasnt much info
`
/var/log$ sudo cat gksudo2.log 
[sudo] password for pd-kerman: 
06/29/24 14:28:32.  User <pd-kerman> ran <gparted> as user <root>
06/29/24 14:28:51.  User <pd-kerman> ran <gparted> as user <pd-kerman>
06/29/24 14:29:10.  User <pd-kerman> ran <gparted> as user <root>
06/29/24 14:33:16.  User <pd-kerman> ran <gparted> as user <root>
06/29/24 14:58:19.  User <pd-kerman> ran <gparted> as user <root>
`


 