### PR TITLE
Investigation required: fixed ‘dbus-launch: command not found error’

### DIFF
--- a/gksudo2-su
+++ b/gksudo2-su
@@ -114,7 +114,9 @@ fi
 #    and remove process group later.
 if grep -q -E "kate|caja" <<< "$@"; then     # Kate or Caja may immediately background themselves
 	dbusl_cmd="   dbus-launch $@"
-else
+	dbusl_cmd="   dbus-run-session $@"
+elses
+	dbusl_cmd="   dbus-launch $@ &"
 	dbusl_cmd="   dbus-launch $@ &"
 fi	
 echo "   ${dbusl_cmd}

--- a/gksudo2-su
+++ b/gksudo2-su
@@ -117,7 +117,7 @@ if grep -q -E "kate|caja" <<< "$@"; then     # Kate or Caja may immediately back
 	dbusl_cmd="   dbus-run-session $@"
 elses
 	dbusl_cmd="   dbus-launch $@ &"
-	dbusl_cmd="   dbus-launch $@ &"
+	dbusl_cmd="   dbus-run-session $@ &"
 fi	
 echo "   ${dbusl_cmd}
    ps > /dev/null   # Only to force update of process tree

--- a/gksudo2-su
+++ b/gksudo2-su
@@ -115,7 +115,7 @@ fi
 if grep -q -E "kate|caja" <<< "$@"; then     # Kate or Caja may immediately background themselves
 	dbusl_cmd="   dbus-launch $@"
 	dbusl_cmd="   dbus-run-session $@"
-elses
+else
 	dbusl_cmd="   dbus-launch $@ &"
 	dbusl_cmd="   dbus-run-session $@ &"
 fi	


### PR DESCRIPTION
*Further investigation required, temporary fix:

It should be trying to run dbus-run-session first as commented tho, but for some reason maybe it just skipped and went for the ‘if-not’ option, i added these two lines on my machine and works fine so far.

=============================================================================

And although it did work there was still some warning boxes kept popping up and I’m not sure whether they are as critical as errors so I’m just gonna post it here as well then :D

As shown chronologically:
![IMG_4573](https://github.com/furryfixer/gksudo2/assets/100339054/f84f51ed-d11b-4a18-9790-5b13c864edc8)

====== and the authentication box pops up, and the apps pops up right after finishing the authentication 

Then close the windows and the second warning box pops up:

![IMG_4575](https://github.com/furryfixer/gksudo2/assets/100339054/eb76662f-1a9b-495d-bb9f-fc1caf86ef7a)

well if these weren’t critical maybe we could just make it print in the console~? 
Or maybe log it somewhere~
Anyway if it wasn’t critical is there any chance i could disable these warning boxes tho~
:D 